### PR TITLE
fix (Layout Service): Now uses screen.width and height to work with iOS Closes #23

### DIFF
--- a/addon/services/device/layout.js
+++ b/addon/services/device/layout.js
@@ -6,6 +6,7 @@ import { run } from '@ember/runloop';
 import Service from '@ember/service';
 import capitalize from '../../utils/capitalize';
 import monitor from '../../lib/monitor';
+import window from 'ember-window-mock';
 
 export default Service.extend(Evented, {
   breakpoints: null,
@@ -117,10 +118,20 @@ export default Service.extend(Evented, {
   },
 
   _currentWidth() {
-    return Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
+    const widths = [
+      window.document.documentElement.clientWidth,
+      window.innerWidth,
+      window.screen.width // for mobile iOS
+    ]
+    return Math.min(...widths.filter(width => width));
   },
 
   _currentHeight() {
-    return Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+    const heights = [
+      window.document.documentElement.clienthHeight,
+      window.innerHeight,
+      window.screen.height // for mobile iOS
+    ]
+    return Math.min(...heights.filter(height => height));
   }
 });

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "ember-source": "~3.1.0-beta.1",
     "ember-source-channel-url": "^1.0.1",
     "ember-try": "^0.2.23",
+    "ember-window-mock": "^0.4.0",
     "eslint-plugin-ember": "^5.0.3",
     "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3",

--- a/tests/unit/services/device/layout-test.js
+++ b/tests/unit/services/device/layout-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import td from 'testdouble';
+import { default as window } from 'ember-window-mock';
 
 module('Unit | Service | device/layout', function(hooks) {
   setupTest(hooks);
@@ -82,5 +83,43 @@ module('Unit | Service | device/layout', function(hooks) {
     service.updateResolution();
 
     assert.equal(td.explain(listener).callCount, 3);
+  });
+
+  test('currentWidth and currentHeight use the correct values from the window', function(assert) {
+    const service = this.owner.factoryFor('service:device/layout').create();
+
+    window.screen.width = 100;
+    window.innerWidth = 0;
+    window.document.documentElement.clientWidth = null;
+    assert.equal(
+      service._currentWidth(),
+      100,
+      'Should ignore values of 0 or null'
+    );
+
+    window.innerWidth = 150;
+    window.document.documentElement.clientWidth = 200;
+    assert.equal(
+      service._currentWidth(),
+      100,
+      'Should choose the smallest value'
+    );
+
+    window.screen.height = 100;
+    window.innerHeight = 0;
+    window.document.documentElement.clientHeight = null;
+    assert.equal(
+      service._currentHeight(),
+      100,
+      'Should ignore values of 0 or null'
+    );
+
+    window.innerHeight = 150;
+    window.document.documentElement.clientHeight = 200;
+    assert.equal(
+      service._currentHeight(),
+      100,
+      'Should choose the smallest value'
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,20 +20,16 @@
   dependencies:
     "@glimmer/di" "^0.2.0"
 
-"@html-next/flexi-config@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@html-next/flexi-config/-/flexi-config-2.1.0.tgz#9ea95f784c23df75ae3e58697b303c52581c7a17"
-
 "@html-next/flexi-config@2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@html-next/flexi-config/-/flexi-config-2.1.1.tgz#9118b36b8b3d05ef553052580cc610965efc2bf9"
 
-"@html-next/flexi-default-styles@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@html-next/flexi-default-styles/-/flexi-default-styles-2.1.0.tgz#ee73964e22f7f4e562b8d79cb8e55dd2886f02c5"
+"@html-next/flexi-default-styles@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@html-next/flexi-default-styles/-/flexi-default-styles-2.1.1.tgz#07ec865961492480667386ea4ee164db87aaf4f8"
   dependencies:
-    "@html-next/flexi-config" "2.1.0"
-    broccoli-merge-trees "^2.0.0"
+    "@html-next/flexi-config" "2.1.1"
+    broccoli-merge-trees "^3.0.0"
     broccoli-plugin "^1.3.0"
     ember-cli-babel "^6.6.0"
     ember-cli-sass "^7.0.0"
@@ -2706,6 +2702,13 @@ ember-try@^0.2.23:
     rimraf "^2.3.2"
     rsvp "^3.0.17"
     semver "^5.1.0"
+
+ember-window-mock@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/ember-window-mock/-/ember-window-mock-0.4.0.tgz#87316623dd1a1414b82b08bb018889a210be91bd"
+  dependencies:
+    broccoli-funnel "^2.0.1"
+    ember-cli-babel "^6.6.0"
 
 encodeurl@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Closes #23
~~This works, but I really want to write a test, which requires a large refactor to the layout service. Basically, rather than using `window` in the service, we'd have to use `this.window` which could be overwritten by the test. Let me know if that's what you want and I'll do the refactor.~~

Wrote tests using ember-window-mock