### PR TITLE
relocates reference to ember-window-mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-preprocess-registry": "^3.0.0",
+    "ember-window-mock": "^0.4.0",
     "rsvp": "^4.0.0"
   },
   "devDependencies": {
@@ -73,7 +74,6 @@
     "ember-source": "~3.2.0-beta.2",
     "ember-source-channel-url": "^1.0.1",
     "ember-try": "^0.2.23",
-    "ember-window-mock": "^0.4.0",
     "eslint-plugin-ember": "^5.1.0",
     "eslint-plugin-node": "^6.0.1",
     "loader.js": "^4.2.3",


### PR DESCRIPTION
fix(deps): relocates reference to `ember-window-mock` in package.json

Fixes #25 