### PR TITLE
Fix clienthHeight typo

### DIFF
--- a/addon/services/device/layout.js
+++ b/addon/services/device/layout.js
@@ -128,7 +128,7 @@ export default Service.extend(Evented, {
 
   _currentHeight() {
     const heights = [
-      window.document.documentElement.clienthHeight,
+      window.document.documentElement.clientHeight,
       window.innerHeight,
       window.screen.height // for mobile iOS
     ]


### PR DESCRIPTION
`device/layout` service has a typo in `_currentHeight` method that prevents getting the `window.document.documentElement.clientHeight` value properly.

Change `window.document.documentElement.clienthHeight` -> `window.document.documentElement.clientHeight`.